### PR TITLE
comment 부분 다시 코드 작성하였습니다.

### DIFF
--- a/server/mainPr/.gitignore
+++ b/server/mainPr/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/SpringImage/**.png

--- a/server/mainPr/build.gradle
+++ b/server/mainPr/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/org.assertj/assertj-core
 	testImplementation 'org.assertj:assertj-core:3.23.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
@@ -5,8 +5,6 @@ import com.team23.mainPr.Domain.Comment.Dto.Request.UpdateCommentEntityDto;
 import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDto;
 import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDtos;
 import com.team23.mainPr.Domain.Comment.Service.CommentService;
-import com.team23.mainPr.Global.Dto.ChildCommonDto;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,8 +13,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
-
-import static com.team23.mainPr.Global.Enum.ChildCommonDtoMsgList.*;
 
 @Controller
 @RequestMapping("/comment")
@@ -27,47 +23,47 @@ public class CommentController {
 
 
     @PostMapping("/post")
-    public ResponseEntity<CommentEntityResponseDto> postComment(@RequestBody @Valid CreateCommentEntityDto dto) {
+    public  ResponseEntity<CommentEntityResponseDto>  postComment(@RequestBody  @Valid  CreateCommentEntityDto dto) {
 
-        CommentEntityResponseDto response = commentService.createCommentEntity(dto);
+         CommentEntityResponseDto response = commentService.createCommentEntity(dto);
 
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return  new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
     @GetMapping("/{commentId}")
-    public ResponseEntity<CommentEntityResponseDto> getComment(@PathVariable @Min(value = 1, message = "commentId must be above 1") Integer commentId) {
+    public  ResponseEntity<CommentEntityResponseDto>  getComment(@PathVariable  @Min(value = 1, message = "commentId must be above 1")  Integer commentId) {
 
-        CommentEntityResponseDto response = commentService.getComment(commentId);
+         CommentEntityResponseDto response = commentService.getComment(commentId);
 
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return  new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
     @PostMapping("/update")
-    public ResponseEntity<CommentEntityResponseDto> updateComment(@RequestBody @Valid UpdateCommentEntityDto dto) {
+    public ResponseEntity<CommentEntityResponseDto> updateComment(@RequestBody  @Valid  UpdateCommentEntityDto dto) {
 
-        CommentEntityResponseDto response = commentService.updateCommentEntity(dto);
+         CommentEntityResponseDto response = commentService.updateCommentEntity(dto);
 
-        return new ResponseEntity<>(response, HttpStatus.OK);
+         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
     @PostMapping("/delete")
-    public ResponseEntity<String> deleteCommentEntity(@RequestParam @Min(value = 1, message = "commentId must be above 1") Integer commentId) {
+    public  ResponseEntity<String>  deleteCommentEntity(@RequestParam  @Min(value = 1, message = "commentId must be above 1")  Integer commentId) {
 
-        String response = commentService.deleteCommentEntity(commentId);
+         String response = commentService.deleteCommentEntity(commentId);
 
-        return new ResponseEntity<>(response, HttpStatus.OK);
+         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 
     @GetMapping("/getComments/{postId}")
-    public ResponseEntity<CommentEntityResponseDtos> getComments(@PathVariable @Valid @Min(value = 1, message = "postId must be above 1") Integer postId) {
+    public  ResponseEntity<CommentEntityResponseDtos>  getComments(@PathVariable  @Valid @Min(value = 1, message = "postId must be above 1")  Integer postId) {
 
-        CommentEntityResponseDtos response = commentService.getComments(postId);
+         CommentEntityResponseDtos response = commentService.getComments(postId);
 
-        return new ResponseEntity<>(response, HttpStatus.OK);
+         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
@@ -3,6 +3,7 @@ package com.team23.mainPr.Domain.Comment.Controller;
 import com.team23.mainPr.Domain.Comment.Dto.Request.CreateCommentEntityDto;
 import com.team23.mainPr.Domain.Comment.Dto.Request.UpdateCommentEntityDto;
 import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDto;
+import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDtos;
 import com.team23.mainPr.Domain.Comment.Service.CommentService;
 import com.team23.mainPr.Global.Dto.ChildCommonDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -65,6 +66,19 @@ public class CommentController {
     public ResponseEntity<ChildCommonDto<CommentEntityResponseDto>> deleteCommentEntity(@RequestParam Integer commentId) {
 
         ChildCommonDto<CommentEntityResponseDto> response = commentService.deleteCommentEntity(commentId);
+
+        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
+            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Operation
+    @GetMapping("/getComments/{postId}")
+    public ResponseEntity<ChildCommonDto<CommentEntityResponseDtos>> getComments(@PathVariable Integer postId) {
+
+        ChildCommonDto<CommentEntityResponseDtos> response = commentService.getComments(postId);
 
         if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
             return new ResponseEntity<>(response, HttpStatus.OK);

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Controller/CommentController.java
@@ -13,6 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+
 import static com.team23.mainPr.Global.Enum.ChildCommonDtoMsgList.*;
 
 @Controller
@@ -22,69 +25,49 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation
+
     @PostMapping("/post")
-    public ResponseEntity<ChildCommonDto<CommentEntityResponseDto>> postComment(@RequestBody CreateCommentEntityDto createCommentEntityDto) {
+    public ResponseEntity<CommentEntityResponseDto> postComment(@RequestBody @Valid CreateCommentEntityDto dto) {
 
-        ChildCommonDto<CommentEntityResponseDto> response = commentService.createCommentEntity(createCommentEntityDto);
+        CommentEntityResponseDto response = commentService.createCommentEntity(dto);
 
-        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation
+
     @GetMapping("/{commentId}")
-    public ResponseEntity<ChildCommonDto<CommentEntityResponseDto>> getComment(@PathVariable Integer commentId) {
+    public ResponseEntity<CommentEntityResponseDto> getComment(@PathVariable @Min(value = 1, message = "commentId must be above 1") Integer commentId) {
 
-        ChildCommonDto<CommentEntityResponseDto> response = commentService.getComment(commentId);
+        CommentEntityResponseDto response = commentService.getComment(commentId);
 
-        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation
+
     @PostMapping("/update")
-    public ResponseEntity<ChildCommonDto<CommentEntityResponseDto>> updateComment(@RequestBody UpdateCommentEntityDto updateCommentEntityDto) {
+    public ResponseEntity<CommentEntityResponseDto> updateComment(@RequestBody @Valid UpdateCommentEntityDto dto) {
 
-        ChildCommonDto<CommentEntityResponseDto> response = commentService.updateCommentEntity(updateCommentEntityDto);
+        CommentEntityResponseDto response = commentService.updateCommentEntity(dto);
 
-        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation
+
     @PostMapping("/delete")
-    public ResponseEntity<ChildCommonDto<CommentEntityResponseDto>> deleteCommentEntity(@RequestParam Integer commentId) {
+    public ResponseEntity<String> deleteCommentEntity(@RequestParam @Min(value = 1, message = "commentId must be above 1") Integer commentId) {
 
-        ChildCommonDto<CommentEntityResponseDto> response = commentService.deleteCommentEntity(commentId);
+        String response = commentService.deleteCommentEntity(commentId);
 
-        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation
+
     @GetMapping("/getComments/{postId}")
-    public ResponseEntity<ChildCommonDto<CommentEntityResponseDtos>> getComments(@PathVariable Integer postId) {
+    public ResponseEntity<CommentEntityResponseDtos> getComments(@PathVariable @Valid @Min(value = 1, message = "postId must be above 1") Integer postId) {
 
-        ChildCommonDto<CommentEntityResponseDtos> response = commentService.getComments(postId);
+        CommentEntityResponseDtos response = commentService.getComments(postId);
 
-        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
-            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/CreateCommentEntityDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/CreateCommentEntityDto.java
@@ -6,11 +6,11 @@ import javax.validation.constraints.NotNull;
 
 @Data
 public class CreateCommentEntityDto {
-    @NotNull(message = "commentContents must not be null")
-    @NotEmpty(message = "commentContents must not be empty")
+     @NotNull(message = "commentContents must not be null")
+     @NotEmpty(message = "commentContents must not be empty")
     String commentContents;
-    @NotNull(message = "writerId must not be null")
+     @NotNull(message = "writerId must not be null")
     Integer writerId;
-    @NotNull(message = "writerId must not be null")
+     @NotNull(message = "writerId must not be null")
     Integer targetPostId;
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/CreateCommentEntityDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/CreateCommentEntityDto.java
@@ -1,11 +1,16 @@
 package com.team23.mainPr.Domain.Comment.Dto.Request;
 
 import lombok.Data;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Data
 public class CreateCommentEntityDto {
-
+    @NotNull(message = "commentContents must not be null")
+    @NotEmpty(message = "commentContents must not be empty")
     String commentContents;
+    @NotNull(message = "writerId must not be null")
     Integer writerId;
+    @NotNull(message = "writerId must not be null")
     Integer targetPostId;
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/UpdateCommentEntityDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/UpdateCommentEntityDto.java
@@ -7,9 +7,9 @@ import javax.validation.constraints.NotNull;
 
 @Data
 public class UpdateCommentEntityDto {
-    @NotNull(message = "commentId must not be null")
+     @NotNull(message = "commentId must not be null")
     Integer commentId;
-    @NotNull(message = "commentContents must not be null")
-    @NotEmpty(message = "commentContents must not be empty")
+     @NotNull(message = "commentContents must not be null")
+     @NotEmpty(message = "commentContents must not be empty")
     String commentContents;
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/UpdateCommentEntityDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Request/UpdateCommentEntityDto.java
@@ -1,9 +1,15 @@
 package com.team23.mainPr.Domain.Comment.Dto.Request;
 
 import lombok.Data;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 
 @Data
 public class UpdateCommentEntityDto {
+    @NotNull(message = "commentId must not be null")
     Integer commentId;
+    @NotNull(message = "commentContents must not be null")
+    @NotEmpty(message = "commentContents must not be empty")
     String commentContents;
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Response/CommentEntityResponseDtos.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Response/CommentEntityResponseDtos.java
@@ -2,7 +2,6 @@ package com.team23.mainPr.Domain.Comment.Dto.Response;
 
 import com.team23.mainPr.Global.Dto.ParentCommonDto;
 import lombok.Data;
-
 import java.util.List;
 
 @Data

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Response/CommentEntityResponseDtos.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Dto/Response/CommentEntityResponseDtos.java
@@ -1,0 +1,11 @@
+package com.team23.mainPr.Domain.Comment.Dto.Response;
+
+import com.team23.mainPr.Global.Dto.ParentCommonDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CommentEntityResponseDtos extends ParentCommonDto {
+    List<CommentEntityResponseDto> comments;
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Repository/CommentRepository.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Repository/CommentRepository.java
@@ -3,5 +3,8 @@ package com.team23.mainPr.Domain.Comment.Repository;
 import com.team23.mainPr.Domain.Comment.Entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
+    List<Comment> findAllByTargetPostId(Integer targetPostId);
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Service/CommentService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Service/CommentService.java
@@ -3,6 +3,7 @@ package com.team23.mainPr.Domain.Comment.Service;
 import com.team23.mainPr.Domain.Comment.Dto.Request.CreateCommentEntityDto;
 import com.team23.mainPr.Domain.Comment.Dto.Request.UpdateCommentEntityDto;
 import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDto;
+import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDtos;
 import com.team23.mainPr.Domain.Comment.Entity.Comment;
 import com.team23.mainPr.Domain.Comment.Mapper.CommentMapper;
 import com.team23.mainPr.Domain.Comment.Repository.CommentRepository;
@@ -10,6 +11,9 @@ import com.team23.mainPr.Global.DefaultTimeZone;
 import com.team23.mainPr.Global.Dto.ChildCommonDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.team23.mainPr.Global.Enum.ChildCommonDtoMsgList.FAIL;
 import static com.team23.mainPr.Global.Enum.ChildCommonDtoMsgList.SUCCESS;
@@ -62,5 +66,18 @@ public class CommentService {
         commentRepository.delete(findComment);
 
         return new ChildCommonDto<>(SUCCESS.getMsg(), null, null);
+    }
+
+    public ChildCommonDto<CommentEntityResponseDtos> getComments(Integer targetPostId) {
+        List<Comment> comments = commentRepository.findAllByTargetPostId(targetPostId);
+
+        if(comments.size() == 0 )
+            return new ChildCommonDto<>(FAIL.getMsg(), null, null);
+        List<CommentEntityResponseDto> commentResponses = new ArrayList<>();
+        comments.stream().forEach(comment -> commentResponses.add(commentMapper.CommentEntityToCommentResponsDto(comment)));
+        CommentEntityResponseDtos result = new CommentEntityResponseDtos();
+        result.setComments(commentResponses);
+
+        return new ChildCommonDto<>(SUCCESS.getMsg(),null,result);
     }
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Service/CommentService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Comment/Service/CommentService.java
@@ -30,25 +30,25 @@ public class CommentService {
     private final CommentRepository commentRepository;
 
     public CommentEntityResponseDto createCommentEntity(CreateCommentEntityDto createCommentEntityDto) {
-
+        //Bean Validation 적용으로 CreateCommentEntityDto 에 누락된 값이 있는지 확인하는 로직 삭제
         Comment newComment = commentMapper.CreateCommentEntityToCommentEntity(createCommentEntityDto);
         newComment.setWriteDate(defaultTimeZone.getNow());
         newComment.setUpdateDate(defaultTimeZone.getNow());
 
         Comment result = commentRepository.getReferenceById(commentRepository.save(newComment).getCommentId());
-
+        //Bean Validation 적용+ControllerExceptionHandler(컨트롤러 예외 핸들러) 사용으로 발생 가능한 에러상황을 서비스에서 처리하지 않도록 변경
         return commentMapper.CommentEntityToCommentResponsDto(result);
     }
 
     public CommentEntityResponseDto getComment(Integer commentId) {
-
+        //Bean Validation 적용+ControllerExceptionHandler(컨트롤러 예외 핸들러) 사용으로 발생 가능한 에러상황을 서비스에서 처리하지 않도록 변경
         Comment findComment = commentRepository.getReferenceById(commentId);
 
         return commentMapper.CommentEntityToCommentResponsDto(findComment);
     }
 
     public CommentEntityResponseDto updateCommentEntity(UpdateCommentEntityDto updateCommentEntityDto) {
-
+        //Bean Validation 적용으로 UpdateCommentEntityDto 에 누락된 값이 있는지 확인하는 로직 삭제
         Comment findComment = commentRepository.getReferenceById(updateCommentEntityDto.getCommentId());
         findComment.setCommentContents(updateCommentEntityDto.getCommentContents());
         commentRepository.flush();
@@ -61,7 +61,8 @@ public class CommentService {
         Comment findComment = commentRepository.getReferenceById(commentId);
 
         commentRepository.delete(findComment);
-
+        //Bean Validation 적용+ControllerExceptionHandler(컨트롤러 예외 핸들러) 사용으로 발생 가능한 에러상황을 서비스에서 처리하지 않도록 변경
+        //단순하게 성공했음을 알리는 메세지만 응답하면 된다.
         return SUCCESS.getMsg();
     }
 
@@ -73,7 +74,8 @@ public class CommentService {
 
         CommentEntityResponseDtos result = new CommentEntityResponseDtos();
         result.setComments(commentResponses);
-
+        //Bean Validation 적용+ControllerExceptionHandler(컨트롤러 예외 핸들러) 사용으로 발생 가능한 에러상황을 서비스에서 처리하지 않도록 변경
+        //다시 생각해보니 검색 결과가 0라면 정상적인 응답이므로 그대로 비어있는 리스트를 응답하면 되는 것이었다. - 불필요한 에러 핸들링 하려고 하지 않기
         return result;
     }
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Login/Controller/LoginController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Login/Controller/LoginController.java
@@ -21,7 +21,7 @@ public class LoginController {
 
     private final LoginService loginService;
 
-    @Operation
+
     @PostMapping
     public ResponseEntity<ChildCommonDto<DoLoginResponseDto>> doLogin(@RequestBody DoLoginDto doLoginDto) {
 
@@ -31,7 +31,7 @@ public class LoginController {
 
     }
 
-    @Operation
+
     @PostMapping("/refeshToken")
     public ResponseEntity<ChildCommonDto<ParentCommonDto>> refeshToken(@RequestParam String token) {
 

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Logout/Controller/LogoutController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Logout/Controller/LogoutController.java
@@ -17,7 +17,7 @@ public class LogoutController {
 
     private final LoginService loginService;
 
-    @Operation
+
     @PostMapping("/logout")
     public ResponseEntity<ChildCommonDto<ParentCommonDto>> doLogout(@RequestParam String Authorization) {
 

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Controller/MemberController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Controller/MemberController.java
@@ -45,15 +45,6 @@ public class MemberController {
      * </pre>
      */
 
-    @Operation
-    @PostMapping("/post/checkInput")
-    public ResponseEntity<ChildCommonDto<MemberResponseDto>> checkInput(@RequestBody CreateMemberDto createMemberDto) throws RuntimeException {
-
-        ChildCommonDto<MemberResponseDto> response = memberService.loginValidation(createMemberDto);
-
-        return new ResponseEntity<>(response, response.getHttpStatus());
-    }
-
     /*
      * refactor : 비밀번호 같은 민감 정보를 전송해도 될까? - response Dto를 만들어서 암호화 할까?
      */

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Controller/MemberController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.team23.mainPr.Domain.Member.Controller;
 
 
+import com.team23.mainPr.Domain.Comment.Dto.Response.CommentEntityResponseDto;
 import com.team23.mainPr.Domain.Member.Dto.Request.CreateMemberDto;
 import com.team23.mainPr.Domain.Member.Dto.Request.FindIdDto;
 import com.team23.mainPr.Domain.Member.Dto.Request.FindPasswordDto;
@@ -8,12 +9,20 @@ import com.team23.mainPr.Domain.Member.Dto.Request.UpdateMemberDto;
 import com.team23.mainPr.Domain.Member.Dto.Response.MemberProfileDto;
 import com.team23.mainPr.Domain.Member.Dto.Response.MemberResponseDto;
 import com.team23.mainPr.Domain.Member.Service.MemberService;
+import com.team23.mainPr.Domain.Picture.Service.PictureService;
 import com.team23.mainPr.Global.Dto.ChildCommonDto;
+import com.team23.mainPr.Global.Dto.ParentCommonDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static com.team23.mainPr.Global.Enum.ChildCommonDtoMsgList.*;
 
 /**
  * <pre>
@@ -34,6 +43,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final PictureService pictureService;
 
     /**
      * <pre>
@@ -65,7 +75,7 @@ public class MemberController {
      * Todo : 서비스 레이어 응답을 어떻게 바꾸어야 계층간 느스한 결합, 재사용성이 좋게 구현할수 있을까 고민하기!
      */
 
-    @Operation
+
     @GetMapping("/{memberId}")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> getMember(@PathVariable Integer memberId) {
 
@@ -74,7 +84,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @GetMapping("profile/{memberId}")
     public ResponseEntity<ChildCommonDto<MemberProfileDto>> getProfile(@PathVariable Integer memberId) {
 
@@ -83,7 +93,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @DeleteMapping("/delete")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> deleteMember(@RequestParam Integer memberId) {
 
@@ -92,7 +102,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PutMapping("profile/{memberId}")
     public ResponseEntity<ChildCommonDto<MemberProfileDto>> updateProfile(@RequestBody UpdateMemberDto updateMemberDto,
                                                                           @PathVariable Integer memberId) {
@@ -102,7 +112,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/post/checkExistEmail")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> checkExistEmail(@RequestParam String email) {
 
@@ -111,7 +121,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/post/checkExistId")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> checkExistId(@RequestParam String id) {
 
@@ -120,7 +130,7 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/post/findId")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> findId(@RequestBody FindIdDto findIdDto) {
 
@@ -129,12 +139,34 @@ public class MemberController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/post/findPassword")
     public ResponseEntity<ChildCommonDto<MemberResponseDto>> findId(@RequestBody FindPasswordDto findPasswordDto) {
 
         ChildCommonDto<MemberResponseDto> response = memberService.findPassword(findPasswordDto);
 
         return new ResponseEntity<>(response, response.getHttpStatus());
+    }
+
+    @PostMapping("/profileImage/post")
+// 업로드하는 파일들을 MultipartFile 형태의 파라미터로 전달된다.
+    //여러개 업로드
+    public ResponseEntity<ChildCommonDto<ParentCommonDto>> upload(@RequestParam MultipartFile file,
+                                                                  @RequestParam Integer memberId) throws IOException {
+
+        ChildCommonDto<ParentCommonDto> response = memberService.setProfilePicture(memberId,file);
+
+        if (response.getMsg().equals(TRUE.getMsg()) || response.getMsg().equals(SUCCESS.getMsg()) || response.getMsg().equals(CREATED.getMsg()))
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        else if (response.getMsg().equals(FAIL.getMsg()) || response.getMsg().equals(FALSE.getMsg()))
+            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @GetMapping("/profileImage/get")
+    public ResponseEntity getDefaultProfileImage(@RequestParam Integer memberId
+    ) throws IOException {
+
+        return memberService.getProfilePicture(memberId);
     }
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Request/CreateMemberDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Request/CreateMemberDto.java
@@ -20,7 +20,7 @@ public class CreateMemberDto extends ParentCommonDto {
     private String password;
     private String nickname;
     private String email;
-    private String profileImageId = "default.png";
+    private Integer profileImageId = 1;
     private String name;
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Request/UpdateMemberDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Request/UpdateMemberDto.java
@@ -6,6 +6,4 @@ import lombok.Data;
 public class UpdateMemberDto {
 
     private String nickname;
-    private String profileImageId;
-
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Response/MemberProfileDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Response/MemberProfileDto.java
@@ -12,6 +12,6 @@ public class MemberProfileDto extends ParentCommonDto {
     private String nickname;
     private String email;
     private ZonedDateTime createdAt;
-    private String profileImageId;
+    private Integer profileImageId;
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Response/MemberResponseDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Dto/Response/MemberResponseDto.java
@@ -13,7 +13,7 @@ public class MemberResponseDto extends ParentCommonDto {
     private String nickname;
     private String email;
     private ZonedDateTime createdAt;
-    private String profileImageId;
+    private Integer profileImageId;
     private String name;
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Entity/Member.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Member/Entity/Member.java
@@ -32,7 +32,7 @@ public class Member {
     private String nickname;
     private String email;
     private ZonedDateTime createdAt;
-    private String profileImageId;
+    private Integer profileImageId;
     private String name;
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Controller/controller.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Controller/controller.java
@@ -1,0 +1,29 @@
+package com.team23.mainPr.Domain.Picture.Controller;
+
+
+import com.team23.mainPr.Domain.Picture.Service.PictureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/image")
+@RequiredArgsConstructor
+public class controller {
+
+    private final PictureService pictureService;
+
+    @GetMapping
+    public ResponseEntity download(@RequestParam Integer memberId) throws IOException {
+
+        pictureService.setDefaultImage();
+
+        return new ResponseEntity("added",HttpStatus.OK);
+    }
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Dto/FileDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Dto/FileDto.java
@@ -1,0 +1,24 @@
+package com.team23.mainPr.Domain.Picture.Dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FileDto {
+    private String uuid;	// unique 한 파일 이름을 만들기 위한 속성
+    private String fileName;	// 실제 파일 이름
+    private String contentType;
+
+
+    public FileDto() {}
+
+    public FileDto(String uuid, String fileName, String contentType) {
+        this.uuid = uuid;
+        this.fileName = fileName;
+        this.contentType = contentType;
+    }
+
+    // setter/getter는 생략
+}
+

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Dto/download_dto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Dto/download_dto.java
@@ -1,0 +1,16 @@
+package com.team23.mainPr.Domain.Picture.Dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class download_dto {
+
+    private String fileName;	// 실제 파일 이름
+    private String contentType;
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Entity/Picture.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Entity/Picture.java
@@ -1,0 +1,19 @@
+package com.team23.mainPr.Domain.Picture.Entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+public class Picture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer imageId;
+    String fileName;
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Repository/PictureRepository.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Repository/PictureRepository.java
@@ -1,0 +1,8 @@
+package com.team23.mainPr.Domain.Picture.Repository;
+
+import com.team23.mainPr.Domain.Picture.Entity.Picture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PictureRepository extends JpaRepository<Picture,Integer> {
+
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Service/PictureService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Service/PictureService.java
@@ -1,0 +1,19 @@
+package com.team23.mainPr.Domain.Picture.Service;
+
+import com.team23.mainPr.Domain.Picture.Entity.Picture;
+import com.team23.mainPr.Domain.Picture.Repository.PictureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PictureService {
+
+    private final PictureRepository pictureRepository;
+
+    public void setDefaultImage()  {
+        Picture defaultImage = new Picture();
+        defaultImage.setFileName("defaultProfileImage.png");
+        pictureRepository.save(defaultImage);
+    }
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentHistory/Controller/RentHistoryController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentHistory/Controller/RentHistoryController.java
@@ -19,7 +19,7 @@ public class RentHistoryController {
 
     private final RentHistoryService rentHistoryService;
 
-    @Operation
+
     @GetMapping("/receive")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDtos>> getReceiveRentHistoryData(@RequestParam Integer memberId) {
 
@@ -28,7 +28,7 @@ public class RentHistoryController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @GetMapping("/send")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDtos>> getSendRentHistoryData(@RequestParam Integer memberId) {
 
@@ -37,7 +37,7 @@ public class RentHistoryController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/post")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDto>> addRentHistoryData(@RequestBody CreateRentHistoryEntityDto createRentHistoryEntityDto) {
 
@@ -46,7 +46,7 @@ public class RentHistoryController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PutMapping
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDto>> updateRentHistoryData(@RequestBody UpdateRentHistoryEntityDto updateRentHistoryDto) {
 
@@ -55,7 +55,7 @@ public class RentHistoryController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @PostMapping("/delete/{rentHistoryId}")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDto>> delete(@PathVariable Integer rentHistoryId) {
 

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentHistory/Controller/RentHistoryController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentHistory/Controller/RentHistoryController.java
@@ -20,7 +20,7 @@ public class RentHistoryController {
     private final RentHistoryService rentHistoryService;
 
     @Operation
-    @GetMapping("/getReceive")
+    @GetMapping("/receive")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDtos>> getReceiveRentHistoryData(@RequestParam Integer memberId) {
 
         ChildCommonDto<RentHistoryResponseDtos> response = rentHistoryService.getReceiveRentHistory(memberId);
@@ -29,7 +29,7 @@ public class RentHistoryController {
     }
 
     @Operation
-    @GetMapping("/getSend")
+    @GetMapping("/send")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDtos>> getSendRentHistoryData(@RequestParam Integer memberId) {
 
         ChildCommonDto<RentHistoryResponseDtos> response = rentHistoryService.getSendRentHistory(memberId);
@@ -38,7 +38,7 @@ public class RentHistoryController {
     }
 
     @Operation
-    @PostMapping
+    @PostMapping("/post")
     public ResponseEntity<ChildCommonDto<RentHistoryResponseDto>> addRentHistoryData(@RequestBody CreateRentHistoryEntityDto createRentHistoryEntityDto) {
 
         ChildCommonDto<RentHistoryResponseDto> response = rentHistoryService.createRentHistory(createRentHistoryEntityDto);

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
@@ -25,7 +25,7 @@ public class RentPostController {
      * </pre>
      */
 
-    @Operation
+
     @PostMapping("/post")
     public ResponseEntity<ChildCommonDto<RentPostResponseDto>> createRentPost(@RequestBody @Parameter(name = "CreateRentPostDto", description = "입력한 렌트 게시글 데이터.", required = true) CreateRentPostEntityDto dto) {
 
@@ -40,7 +40,7 @@ public class RentPostController {
      * </pre>
      */
 
-    @Operation
+
     @PutMapping("/update")
     public ResponseEntity<ChildCommonDto<RentPostResponseDto>> updateRentPost(@RequestBody @Parameter(name = "CreateRentPostDto", description = "입력한 게시글 데이터.", required = true) UpdateRentPostDto updateRentPostDto,
                                                                               @RequestParam @Parameter(name = "postId", description = "게시글 식별 번호.", required = true) Integer postId) {
@@ -49,7 +49,7 @@ public class RentPostController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @Operation
+
     @DeleteMapping("/delete")
     public ResponseEntity<ChildCommonDto<RentPostResponseDto>> updateRentPost(@RequestParam @Parameter(name = "postId", description = "게시글 식별 번호.", required = true) Integer postId) {
         ChildCommonDto<RentPostResponseDto> response = RentPostService.deleteRentPost(postId);
@@ -63,7 +63,7 @@ public class RentPostController {
      * </pre>
      */
 
-    @Operation
+
     @GetMapping("/{postId}")
     public ResponseEntity<ChildCommonDto<RentPostResponseDto>> getRentPost(@PathVariable @Parameter(name = "postId", description = "게시글 식별 번호.", required = true) Integer postId) {
         ChildCommonDto<RentPostResponseDto> response = RentPostService.getRentPost(postId);

--- a/server/mainPr/src/main/java/com/team23/mainPr/Global/CustomException/ErrorData.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Global/CustomException/ErrorData.java
@@ -2,6 +2,7 @@ package com.team23.mainPr.Global.CustomException;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 /**
  * <pre>
@@ -20,12 +21,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ErrorData {
 
-    INVALID_REGISTER_MEMBER_ID("1001", "잘못된 로그인 ID 형식"),
-    INVALID_REGISTER_MEMBER_PASSWORD("1002", "잘못된 로그인 비밀번호 형식"),
-    INVALID_REGISTER_MEMBER_NICKNAME("1001", "잘못된 로그인 ID 형식"),
-    CLASS_CASTING_EXCEPTION("1501", "잘못된 BODY 입력"),
+    INVALID_REGISTER_MEMBER_ID(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"),
+    INVALID_REGISTER_MEMBER_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 로그인 비밀번호 형식"),
+    INVALID_REGISTER_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"),
+    CLASS_CASTING_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 BODY 입력"),
+    MISSING_REQUIRED_DATA(HttpStatus.BAD_REQUEST,"요청에 필요한 데이터가 누락")
     ;
 
-    private final String code;
+    private final HttpStatus code;
     private final String reason;
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Global/CustomException/ErrorData.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Global/CustomException/ErrorData.java
@@ -21,11 +21,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorData {
 
-    INVALID_REGISTER_MEMBER_ID(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"),
-    INVALID_REGISTER_MEMBER_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 로그인 비밀번호 형식"),
-    INVALID_REGISTER_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"),
-    CLASS_CASTING_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 BODY 입력"),
-    MISSING_REQUIRED_DATA(HttpStatus.BAD_REQUEST,"요청에 필요한 데이터가 누락")
+     INVALID_REGISTER_MEMBER_ID(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"), 
+     //잘못된 요청이 발생한 이유를 메세지로 구별을 하기 위한 에러 데이터 생성
+     INVALID_REGISTER_MEMBER_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 로그인 비밀번호 형식"),
+     INVALID_REGISTER_MEMBER_NICKNAME(HttpStatus.BAD_REQUEST, "잘못된 로그인 ID 형식"),
+     CLASS_CASTING_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 BODY 입력"),
+     MISSING_REQUIRED_DATA(HttpStatus.BAD_REQUEST,"요청에 필요한 데이터가 누락")
     ;
 
     private final HttpStatus code;

--- a/server/mainPr/src/main/java/com/team23/mainPr/Global/Dto/ChildCommonDto.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Global/Dto/ChildCommonDto.java
@@ -38,4 +38,9 @@ public class ChildCommonDto<T extends ParentCommonDto> {
     public HttpStatus getHttpStatus() {
         return this.httpStatus;
     }
+
+    public ChildCommonDto(HttpStatus statusCode, T dto){
+        this.httpStatus = statusCode;
+        this.t = dto;
+    }
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Global/ExceptionHandler/ControllerExceptionHandler.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Global/ExceptionHandler/ControllerExceptionHandler.java
@@ -1,22 +1,32 @@
 package com.team23.mainPr.Global.ExceptionHandler;
 
 import com.team23.mainPr.Global.CustomException.CustomException;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ControllerExceptionHandler {
 
-    @ExceptionHandler
-    public Object handleControllerException(Exception e) {
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    @Order(value = 3)
+    public ResponseEntity<String> methodArgumentValidException(MethodArgumentNotValidException e) {
 
-        CustomException ex;
-
-        if (e instanceof CustomException) {
-            ex = (CustomException) e;
-            return ex.getErrordata();
-        }
-
-        return e.getMessage();
+        return new ResponseEntity<>(e.getMessage().split(";")[5].replace("default message [","").replace("]] ","") ,HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler
+    @Order(value = 7)
+    public ResponseEntity<String> handleControllerException(CustomException e) {
+        return new ResponseEntity<>(e.getErrordata().getReason(), e.getErrordata().getCode());
+    }
+    @ExceptionHandler
+    @Order(value = 11)
+    public ResponseEntity<String> handleControllerException(Exception e) {
+        return new ResponseEntity<>(e.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Global/ExceptionHandler/ControllerExceptionHandler.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Global/ExceptionHandler/ControllerExceptionHandler.java
@@ -11,22 +11,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ControllerExceptionHandler {
 
-    @ExceptionHandler({MethodArgumentNotValidException.class})
-    @Order(value = 3)
+     @ExceptionHandler({MethodArgumentNotValidException.class})
+     @Order(value = 3)
     public ResponseEntity<String> methodArgumentValidException(MethodArgumentNotValidException e) {
-
-        return new ResponseEntity<>(e.getMessage().split(";")[5].replace("default message [","").replace("]] ","") ,HttpStatus.BAD_REQUEST);
+        //Bean Validation 이 throw 하는 에러 객체에서 필요한 메세지만 분리하여 응답하기.
+          return new ResponseEntity<>(e.getMessage().split(";")[5].replace("default message [","").replace("]] ","") ,HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler
-    @Order(value = 7)
-    public ResponseEntity<String> handleControllerException(CustomException e) {
-        return new ResponseEntity<>(e.getErrordata().getReason(), e.getErrordata().getCode());
+     @ExceptionHandler
+     @Order(value = 7)
+     public ResponseEntity<String> handleControllerException(CustomException e) {
+         //커스텀 에러 데이터에 대해서 이유 메세지와 status code 응답하기
+         return new ResponseEntity<>(e.getErrordata().getReason(), e.getErrordata().getCode());
     }
-    @ExceptionHandler
-    @Order(value = 11)
-    public ResponseEntity<String> handleControllerException(Exception e) {
-        return new ResponseEntity<>(e.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR);
+     @ExceptionHandler
+     @Order(value = 11)
+     public ResponseEntity<String> handleControllerException(Exception e) {
+         //생각해보면 모든 에러상황에 대해 처리하는 것은 친절하지만 너무 비효율적일 수 있다. 못잡은 에러는 500번 보내주고 프론트에서 알아서 처리하도록 하게 하여야겠다.
+          return new ResponseEntity<>(e.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 }


### PR DESCRIPTION
서비스에서 과도하게 에러 케이스를 검출하려고 했던 부분을 Bean Validation 적용으로 제거하였고
공통 dto 사용으로 인해 불필요하게 늘어난 응답부분을 공통 dto 대신 개별 dto와 상태코드를 응답하도록 변경하여 코드를 간결하게 수정하였습니다.

컨트롤러에서는 정상응답에 대해서만 확인할 수 있어도 충분하다고 생각했습니다.
대신에 에러 상황에 대해 컨트롤러 예외 핸들러가 메세지와 상태코드를 응답 할 수 있도록 수정하였습니다.