### PR TITLE
[feat] 렌트 게시글에 이미지 첨부/ 첨부된 이미지 리스트 조회/ 이미지 조회 기능 추가

### DIFF
--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Entity/Picture.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/Picture/Entity/Picture.java
@@ -1,0 +1,33 @@
+package com.team23.mainPr.Domain.Picture.Entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Picture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer imageId;
+    String fileName;
+    Integer postId;
+
+    public Picture(String fileName) {
+        this.fileName = fileName;
+    }
+    public Picture(String fileName, Integer postId) {
+
+        this.fileName = fileName;
+        this.postId = postId;
+    }
+
+}

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
@@ -57,5 +57,19 @@ public class RentPostController {
         return RentPostService.getRentPost(postId);
     }
 
+    @PostMapping("/images")
+    public String postImages(@RequestParam(value="image") List<MultipartFile> files, @RequestParam Integer postId) throws IOException {
+        return RentPostService.postImages(files, postId);
+    }
+
+    @GetMapping("/images/get")
+    public List<Integer> getImages(@RequestParam Integer postId) {
+        return RentPostService.getPostImages(postId);
+    }
+
+    @GetMapping(value = "/image/get", produces = "image/png")
+    public Resource getImage(@RequestParam Integer imageId) throws IOException {
+        return RentPostService.getImage(imageId);
+    }
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
@@ -84,5 +84,36 @@ public class RentPostService {
         return rentPostMapper.RentPostToRentPostResponseDto(result);
     }
 
+    public String postImages(List<MultipartFile> files, Integer postId) throws IOException {
+
+        if (!files.isEmpty()) {
+            for(MultipartFile file : files)
+            {
+                String uuid = UUID.randomUUID().toString();
+                File newFileName = new File(System.getProperty("user.home") + uploadPath + "/" + uuid + "_" + file.getOriginalFilename());
+                file.transferTo(newFileName);
+
+                pictureRepository.save(new Picture(uuid + "_" + file.getOriginalFilename(),postId)).getImageId();
+            }
+        }
+
+        return SUCCESS.getMsg();
+    }
+
+    public List<Integer> getPostImages(Integer postId) {
+
+        List<Integer> result = new ArrayList<>();
+
+        pictureRepository.findByPostId(postId).stream().forEach(picture -> { result.add(picture.getImageId());});
+
+        return result;
+    }
+    public Resource getImage(Integer imageId) throws IOException {
+
+        Path path = Paths.get(System.getProperty("user.home") + uploadPath + "/" + pictureRepository.getReferenceById(imageId).getFileName());
+
+        return new InputStreamResource(Files.newInputStream(path));
+    }
+
 
 }


### PR DESCRIPTION
- 스프링의 Multipart 프레임워크를 이용하여 게시글에 이미지를 첨부 할 수 있도록 기능을 구현 하였습니다. 
- 데이터베이스 이용을 위하여 이미지 관련 엔티티를 생성하였습니다.
- 이미지 파일이 저장되는 경로는 서버 환경과 로컬 환경이 다르기 때문에 환경 변수를 입력 받아 파일이 저장되는 서브 디렉토리만 새로 지정하는 방식으로 서버에서도, 로컬에서도 동작이 가능하도록 하였습니다.(서브 디렉토리는 꼭 미리 생성이 필요합니다. 없을 경우 에러 발생)