### PR TITLE
[feat] 간단한 검색 기능 구현

### DIFF
--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
@@ -87,5 +87,9 @@ public class RentPostController {
                                                   @RequestParam(defaultValue = "category")  String category){
         return rentPostService.getRentPosts(pageable, rentStatus, category);
     }
-    
+
+    @PostMapping("/search")
+    public List<RentPostResponseDto> getRentPosts(@RequestParam  String phrase){
+        return rentPostService.searchAll(phrase);
+    }
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Repository/RentPostRepository.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Repository/RentPostRepository.java
@@ -19,4 +19,9 @@ public interface RentPostRepository extends JpaRepository<RentPost, Integer> {
 
     Page<RentPost> findAllByRentStatusAndCategoryContaining(Pageable pageable, Boolean rentStatus, String category);
 
+    @Query(value = "SELECT p.RENT_POST_ID\n" +
+            "FROM RENT_POST as p\n" +
+            "WHERE p.rent_post_name REGEXP ?1 ;", nativeQuery = true)
+//native query only use order parameter
+    List<Object> search(String phrase);
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
@@ -134,4 +134,13 @@ public class RentPostService {
         return response;
     }
 
+    public List<RentPostResponseDto> searchAll(String phrase) {
+        List<RentPostResponseDto> result = new ArrayList<>();
+        rentPostRepository.search("" + phrase.replace(" ", "|").trim() + "")
+                .stream().forEach(
+                        rentPostId ->{
+                            result.add(rentPostMapper.RentPostToRentPostResponseDto(rentPostRepository.getReferenceById((Integer) rentPostId)));
+                        });
+        return result;
+    }
 }


### PR DESCRIPTION
### 적용이 가능 할 것 같은 해결 방법 
- FULL TEXT SEARCH
- QUERY DSL 

### 질문 내용
-  계속 바뀌는 검색어로 인해 JPQL이나 쿼리 메소드로는 아이디어가 떠오르지 않아 네이티브 쿼리를 이용해서 간단하게 게시글 제목에 대한 검색 기능을 구현했습니다. 
이제 저 방법에서 ODER BY , GROUP BY 등 을 적용해서 기능을 점점 붙여나갈지 처음부터 다시 다른 방법을 사용해야 하는지 고민이 되어 리뷰 요청합니다 ㅠ