### PR TITLE
[feat] h2의 FTsearch 적용

### DIFF
--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Controller/RentPostController.java
@@ -93,5 +93,9 @@ public class RentPostController {
         return rentPostService.searchAll(phrase);
     }
 
+    @PostMapping("/ftSearch")
+    public List<RentPostResponseDto> ftSearch(@RequestParam  String phrase){
+        return rentPostService.ftSearchAll(phrase);
+    }
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Repository/RentPostRepository.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Repository/RentPostRepository.java
@@ -25,5 +25,7 @@ public interface RentPostRepository extends JpaRepository<RentPost, Integer> {
 //native query only use order parameter
     List<Integer> search(String phrase);
 
+    @Query(value = " SELECT T.* FROM FT_SEARCH_DATA( ?1 , 0, 0) FT, RENT_POST T where T.RENT_POST_ID=FT.KEYS[1] ", nativeQuery = true)
+    List<RentPost> ftSearch(String phrase);
 
 }

--- a/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
+++ b/server/mainPr/src/main/java/com/team23/mainPr/Domain/RentPost/Service/RentPostService.java
@@ -144,5 +144,13 @@ public class RentPostService {
         return result;
     }
 
-   
+    public List<RentPostResponseDto> ftSearchAll(String phrase) {
+        List<RentPostResponseDto> result = new ArrayList<>();
+        rentPostRepository.ftSearch(""+phrase+"")
+                .stream().forEach(
+                        rentPost ->{
+                            result.add(rentPostMapper.RentPostToRentPostResponseDto((RentPost) rentPost));
+                        });
+        return result;
+    }
 }


### PR DESCRIPTION
### H2의 Full text search 라이브러리를 적용하였습니다.
- 아직 인덱스에 대해서 활용을 잘 못하는 상태입니다.
- Full text search 를 위하여 Full text search에서 필요로 하는 인덱스를 별도로 생성해야 합니다. 
- RENT_POST 테이블 에 대해 RENT_POST_NAME 칼럼을 인덱스로 등록합니다. 이후에는 이를 위한 sql을 별도의 메소드로 구현하여 호출하는 방식을 사용할 예정입니다.
- 검색을 수행하는 쿼리문은 네이티브 쿼리를 이용하여 List의 형태로 엔티티를 응답 받고, 이를 dto에 맵핑하여 최종적으로 응답합니다.